### PR TITLE
Remove library search path for swift 5

### DIFF
--- a/framework/LoopMeUnitedSDK.xcodeproj/project.pbxproj
+++ b/framework/LoopMeUnitedSDK.xcodeproj/project.pbxproj
@@ -1252,10 +1252,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)";
 				MARKETING_VERSION = 7.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.loopme.sdk.LoopMeUnitedSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1298,10 +1295,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)";
 				MARKETING_VERSION = 7.4.5;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.loopme.sdk.LoopMeUnitedSDK;


### PR DESCRIPTION
This fix allows for the SDK to be linked and build in Xcode. The build script continues to work as expected. This change fixes a project breaking change introduced [here](https://github.com/loopme/ios-united-sdk/commit/5c9ae3365cddd96d3b9ba55cf3ab69eb1302b73f?diff=unified&w=0#diff-5e940738475f76c3444d348a7a2825f86caedd8a8bc246de1adb53e1f78d709aR1307) in 7.2.0

Before:
<img width="1512" alt="Screenshot 2024-05-31 at 12 46 03 PM" src="https://github.com/loopme/ios-united-sdk/assets/181593/733f7eec-1dda-4c29-8bb7-df48a0166e4d">

After:
<img width="1512" alt="Screenshot 2024-05-31 at 12 46 46 PM" src="https://github.com/loopme/ios-united-sdk/assets/181593/c2381072-6393-4553-9a52-445b9f7effa7">
