### PR TITLE
[SDK-268] Move "consent" object to correct place

### DIFF
--- a/framework/LoopMeUnitedSDK/Core/Internal/Builder/LoopMeORTBTools.m
+++ b/framework/LoopMeUnitedSDK/Core/Internal/Builder/LoopMeORTBTools.m
@@ -151,7 +151,8 @@ static NSString *_userAgent;
             @"yob": @(self.targeting.yearOfBirth),
             @"keywords": self.targeting.keywords,
             @"ext": @{}
-        } : @{@"ext": @{}},
+        } : @{@"ext": @{},
+              @"consent": [LoopMeGDPRTools getConsentValue]},
         @"tmax": @700,
         @"bcat": @[@"IAB25-3", @"IAB25", @"IAB26"]
     }];

--- a/framework/LoopMeUnitedSDK/Core/Internal/Builder/LoopMeORTBTools.m
+++ b/framework/LoopMeUnitedSDK/Core/Internal/Builder/LoopMeORTBTools.m
@@ -150,6 +150,7 @@ static NSString *_userAgent;
             @"gender": self.targeting.genderParameter,
             @"yob": @(self.targeting.yearOfBirth),
             @"keywords": self.targeting.keywords,
+            @"consent": [LoopMeGDPRTools getConsentValue],
             @"ext": @{}
         } : @{@"ext": @{},
               @"consent": [LoopMeGDPRTools getConsentValue]},


### PR DESCRIPTION
We had wrong place for "consent" object . Here is moving it to correct place be ORTB 2.6 to "user. consent".
