### PR TITLE
[SDK-252] Remove pos from video object

### DIFF
--- a/framework/LoopMeUnitedSDK/Core/Internal/Builder/LoopMeORTBTools.m
+++ b/framework/LoopMeUnitedSDK/Core/Internal/Builder/LoopMeORTBTools.m
@@ -201,7 +201,6 @@ static NSString *_userAgent;
         @"h": @(size.height),
         @"companiontype": @[@1],
         @"companionad": @[@{
-            @"pos": @7,
             @"w": @(size.width),
             @"h": @(size.height),
             @"format": @[@{


### PR DESCRIPTION
As we decide that `pos` will be set from SSP by backend we don't need this `video.pos` object in SDK on this time 