### PR TITLE
[SDK-277] Added SessionDuration and impdepth to user.ext object

### DIFF
--- a/framework/LoopMeUnitedSDK/Core/Internal/Builder/LoopMeORTBTools.m
+++ b/framework/LoopMeUnitedSDK/Core/Internal/Builder/LoopMeORTBTools.m
@@ -24,6 +24,7 @@
 #import "LoopMeAudioCheck.h"
 #import "LoopMeGlobalSettings.h"
 #import "LoopMeErrorEventSender.h"
+#import "LoopMeSDK.h"
 
 static NSString *_userAgent;
 
@@ -153,8 +154,14 @@ static NSString *_userAgent;
             @"yob": @(self.targeting.yearOfBirth),
             @"keywords": self.targeting.keywords,
             @"consent": [LoopMeGDPRTools getConsentValue],
-            @"ext": @{}
-        } : @{@"ext": @{},
+            @"ext": @{
+                @"sessionduration": [[LoopMeSDK shared] timeElapsedSinceStart],
+                @"impdepth": [[LoopMeSDK shared] sessionDepthForAppKey: self.appKey]
+            }
+        } : @{@"ext": @{
+            @"sessionduration": [[LoopMeSDK shared] timeElapsedSinceStart],
+            @"impdepth": [[LoopMeSDK shared] sessionDepthForAppKey: self.appKey]
+        },
               @"consent": [LoopMeGDPRTools getConsentValue]},
         @"tmax": @700,
         @"bcat": @[@"IAB25-3", @"IAB25", @"IAB26"]

--- a/framework/LoopMeUnitedSDK/Core/Internal/Controllers/LoopMeVPAIDAdDisplayController.m
+++ b/framework/LoopMeUnitedSDK/Core/Internal/Controllers/LoopMeVPAIDAdDisplayController.m
@@ -176,6 +176,7 @@ NSString * const _kLoopMeVPAIDAdErrorCommand = @"vpaidAdError";
     NSError *impError;
     
     UIView *containerView = self.delegate.containerView;
+    [[LoopMeSDK shared] updateSessionDepth:self.delegate.appKey];
     [self.vpaidClient resizeAdWithWidth:containerView.bounds.size.width height:containerView.bounds.size.height viewMode:LoopMeVPAIDViewMode.fullscreen];
 }
 

--- a/framework/LoopMeUnitedSDK/Core/Internal/LoopMeSDK.m
+++ b/framework/LoopMeUnitedSDK/Core/Internal/LoopMeSDK.m
@@ -16,6 +16,8 @@
 @interface LoopMeSDK ()
 
 @property (nonatomic) BOOL isReady;
+@property (nonatomic, strong) NSDate *startSessionTime;
+@property (nonatomic, strong) NSMutableDictionary *sessionDepth;
 
 @end
 
@@ -26,6 +28,7 @@
     
     if (!instance) {
         instance = [[LoopMeSDK alloc] init];
+        instance.sessionDepth = [[NSMutableDictionary alloc] init];
     }
     
     return instance;
@@ -69,7 +72,37 @@
     [[LoopMeGDPRTools sharedInstance] prepareConsent];
     [LoopMeGlobalSettings sharedInstance];
     self.isReady = YES;
+    
+    // Initialize the start for session duration time here
+    [self startSession];
+
     completionBlock(YES, nil);
+}
+
+- (NSNumber *)timeElapsedSinceStart {
+    if (self.startSessionTime) {
+        NSTimeInterval timeInterval = [[NSDate date] timeIntervalSinceDate:self.startSessionTime];
+        return @(round(timeInterval));
+    }
+    return @0;
+}
+
+-(void)startSession {
+    if (!self.startSessionTime) {
+        self.startSessionTime = [NSDate date];
+    }
+}
+
+-(void)updateSessionDepth: (NSString* )appKey {
+    NSNumber* count = [self.sessionDepth valueForKey:appKey];
+    NSNumber* value = count ? [NSNumber numberWithInt: count.intValue + 1] : [NSNumber numberWithInt: 1];
+    [self.sessionDepth setValue: value  forKey: appKey];
+}
+
+- (NSNumber *)sessionDepthForAppKey:(NSString *)appKey {
+    NSNumber *depth = [self.sessionDepth valueForKey: appKey];
+    
+    return depth ?: @0;
 }
 
 @end

--- a/framework/LoopMeUnitedSDK/Core/LoopMeSDK.h
+++ b/framework/LoopMeUnitedSDK/Core/LoopMeSDK.h
@@ -48,7 +48,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)init: (LoopMeSDKConfiguration *) configuration completionBlock: (void(^_Nullable)(BOOL, NSError * _Nullable))completionBlock;
     
 - (void)init: (void(^_Nullable)(BOOL, NSError * _Nullable))completionBlock;
-    
+
+// Start session time
+- (NSNumber *)timeElapsedSinceStart;
+
+// Update sessionDepth value depended of appKey
+-(void)updateSessionDepth: (NSString* )appKey;
+
+// Take sessionDepth value depended of appKey
+- (NSNumber *)sessionDepthForAppKey:(NSString *)appKey;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
In this MR I added `sessionduration` and   `impdepth` to `user.ext`. 
Sessionduration start time is when SDK was init. impdepth is write value only when impression event is calling and set value from appkey. When we what take the value for `impdepth` we looking the appkey in dictionary and if we don't have it we setup value `0`. More details in ticket comments