### PR TITLE
Integration Workaround - Switching to Custom Error Types

### DIFF
--- a/framework/LoopMeUnitedSDK/Core/Internal/Utility/LoopMeLogging.m
+++ b/framework/LoopMeUnitedSDK/Core/Internal/Utility/LoopMeLogging.m
@@ -167,7 +167,7 @@ static dispatch_once_t onceToken;
 }
 
 - (void)startSendingTask {
-    [LoopMeErrorEventSender sendError:LoopMeEventErrorTypeLog errorMessage:@"" info:@{ kErrorInfoAppKey : [LoopMeGlobalSettings sharedInstance].appKeyForLiveDebug, @"debug_logs": [self logs]  }];
+    [LoopMeErrorEventSender sendError:LoopMeEventErrorTypeCustom errorMessage:@"" info:@{ kErrorInfoAppKey : [LoopMeGlobalSettings sharedInstance].appKeyForLiveDebug, @"debug_logs": [self logs]  }];
         
     [self removeLogs];
     dispatch_semaphore_signal(sema);


### PR DESCRIPTION
As part of the ongoing effort to integrate `LoopMeErrorEventSender` into our logging infrastructure, I've implemented a temporary workaround by switching from using custom error types (`LoopMeEventErrorTypeLog`) to leveraging existing custom error types (`LoopMeEventErrorTypeCustom`). This change will facilitate the successful integration of event sending and logging within the LoopMe framework.